### PR TITLE
Fix: corrected bounding box scaling logic

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -199,8 +199,6 @@ def detect2d(
             s += '%gx%g ' % im.shape[2:]  # print string
 
             if len(det):
-                # Rescale boxes from img_size to im0 size
-                det[:, :4] = scale_coords(im.shape[2:], det[:, :4], im0.shape).round()
 
                 # Print results
                 for c in det[:, -1].unique():
@@ -245,7 +243,7 @@ def plot3d(
     if img_2d is not None:
         plot_2d_box(img_2d, box_2d)
 
-    plot_3d_box(img, proj_matrix, orient, dimensions, location) # 3d boxes
+    plot_3d_box(img, proj_matrix, orient, dimensions, location) # 3d boxes and resizing of boxes 
 
     return location
 

--- a/library/Plotting.py
+++ b/library/Plotting.py
@@ -92,6 +92,8 @@ def plot_3d_box(img, cam_to_img, ry, dimension, center):
     box_3d = []
     for corner in corners:
         point = project_3d_pt(corner, cam_to_img)
+        point[0] =(int)(point[0]*1242/640) # change 1242x375 to whatever your im0.shape is
+        point[1] =(int)(point[1]*375/224)
         box_3d.append(point)
 
     #LINE


### PR DESCRIPTION
This pull request addresses inaccurate scaling of bounding boxes in the projection pipeline.
The original logic was based on using the scale_coords function, which resulted in inaccurate bounding boxes.

🛠️ Changes Made
Removed scale_coords logic to handle transformation from 640x224 back to 1241x376 using the unitary method.
Now the transformation happens directly in plot_3d_box function of plotting.py file.
Before:
<img width="1242" height="375" alt="1241x376_image" src="https://github.com/user-attachments/assets/8573b1b4-bbac-4abd-817e-55f3def7feee" />
After:
<img width="1242" height="375" alt="fixed_1241x376" src="https://github.com/user-attachments/assets/259e6eab-5272-4901-b3ab-0062f984fd39" />
